### PR TITLE
adding remove_metadata_field helper function and the remove_field method...

### DIFF
--- a/voce-post-meta.php
+++ b/voce-post-meta.php
@@ -261,10 +261,12 @@ class Voce_Meta_Group {
 	 */
 	public function remove_field( $id ) {
 
-		if ( isset( $this->fields[$id] ) )
+		if ( isset( $this->fields[$id] ) ){
 			unset( $this->fields[$id] );
+			return true;
+		}
 
-		return $this->fields;
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
... it calls. allows us to dynamically control which meta fields a users is displayed based on another value. ide removed trailing whitespace throughout file. fixed call to wp_parse_args where parameters were backwards.

The purpose of adding the remove_metdata_field helper function and the remove_field method is to have dynamic fields. So I could add a meta field with a type of dropdown and depending on the value of that dropdown, I want to either show or hide other post meta fields in the edit screen.

An example of how I would use this is within https://github.com/voceconnect/wp-twitter-cards where I have different meta fields being used for different Twitter Card types. Fields that are relevant to only the product card, get added only when the product card is selected, and the same goes for the other card types.

I've also changed the way you display the description for a meta field as WP has a class styled specifically for this and by wrapping it in a span with a class of description gives it a subtle italicized look that just looks more appropriate for a description of a field.
