### PR TITLE
3.9 & TinyMCE Compatibility 

### DIFF
--- a/voce-post-meta.php
+++ b/voce-post-meta.php
@@ -410,7 +410,7 @@ class Voce_Meta_Field implements iVoce_Meta_Field {
 		if ( isset( $_POST[ $this->group->id ][ $this->id ] ) ) {
 			$new_value = $_POST[ $this->group->id ][ $this->id ];
 		} elseif ( isset( $_POST[ $this->group->id . '_' . $this->id ] ) ) {
-			// see voce_wp_editor_field_display function, this is added to check for any instances of the wp_editor calls which were changed to use the get_input_id method instead of the get_name method because WP3.9 deprecated the usage of brackets in the name value for the wp_editor
+			// see voce_wp_editor_field_display function
 			$new_value = $_POST[ $this->group->id . '_' . $this->id ];
 		} 
 		foreach ($this->sanitize_callbacks as $callback) {


### PR DESCRIPTION
Notice: wp_editor() was called with an argument that is <strong>deprecated</strong> since version 3.9! TinyMCE editor IDs cannot have brackets.
